### PR TITLE
Use `ThreadPoolExecutor` instead of Bare Threads

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,0 @@
-import numpy as np
-from multiprocessing import Pool
-import matplotlib.pyplot as plt

--- a/bank.py
+++ b/bank.py
@@ -221,17 +221,16 @@ class Bank(BaseClass):
         :param message: it can be everything
         :return: a dictionary with these keys: [status: Bool, send_time: datetime object]
         """
-        self.lock.acquire()
+
         send_time = datetime.now()
 
-        try:
-            message = pickle.dumps(message)
-            conn.sendall(message)
-            status = True
-        except Exception:
-            status = False
-
-        self.lock.release()
+        with self.lock:
+            try:
+                message = pickle.dumps(message)
+                conn.sendall(message)
+                status = True
+            except Exception:
+                status = False
 
         return {
             "status": status,  # True (succeeded) or False (failed)

--- a/bank.py
+++ b/bank.py
@@ -19,12 +19,8 @@ class Bank(BaseClass):
     branches_public_details = []
     next_id = 0
 
-    # Class Methods
-    @classmethod
-    def load_class_vars(
-        cls,
-    ):
-
+    @staticmethod
+    def load_class_vars():
         while True:
             try:
                 if not Bank.bank_file.is_file():
@@ -41,10 +37,8 @@ class Bank(BaseClass):
             except Exception:
                 continue
 
-    @classmethod
-    def save_class_vars(
-        cls,
-    ):
+    @staticmethod
+    def save_class_vars():
         with open(Bank.bank_file, "w") as f:
             json.dump({"branch_details": Bank.branches_public_details}, f)
 

--- a/bank.py
+++ b/bank.py
@@ -393,7 +393,7 @@ class Bank(BaseClass):
                 "amount": amount,
                 "subject": message["subject"],
             }
-            if "initiator" in message.keys():
+            if "initiator" in message:
                 last_message["initiator"] = message["initiator"]
 
             self.branches[sender_index]["last_message"].put(last_message)
@@ -635,18 +635,19 @@ class Bank(BaseClass):
         """
 
         bid = self._id_to_index(bid)
+        branch = self.branches[bid]
 
         if mode == "server":
             (
-                self.branches[bid]["in_conn"],
-                self.branches[bid]["address"],
-            ) = self.branches[bid]["in_sock"].accept()
+                branch["in_conn"],
+                branch["address"],
+            ) = branch["in_sock"].accept()
 
         else:  # client
             while True:
                 address, port = (
-                    self.branches[bid]["address"],
-                    self.branches[bid]["port"],
+                    branch["address"],
+                    branch["port"],
                 )
-                self.branches[bid]["out_conn"].connect((address, port))
+                branch["out_conn"].connect((address, port))
                 break

--- a/bank.py
+++ b/bank.py
@@ -14,7 +14,10 @@ class Bank(BaseClass):
 
     # Class Variables
     consts = Constants()
-    consts.dir_bank.mkdir() if not consts.dir_bank.is_dir() else None
+
+    if not consts.dir_bank.is_dir():
+        consts.dir_bank.mkdir()
+
     bank_file = consts.dir_bank / "bank.json"
     branches_public_details = []
     next_id = 0
@@ -43,7 +46,7 @@ class Bank(BaseClass):
             json.dump({"branch_details": Bank.branches_public_details}, f)
 
     def __init__(
-        self, id=None, balance=1_000_000, address="localhost", max_number_of_send=1_000
+        self, balance=1_000_000, address="localhost", max_number_of_send=1_000
     ):
 
         self._log("Initiating ...")
@@ -68,7 +71,8 @@ class Bank(BaseClass):
         if self.max_n_send is None:
             self.max_n_send = max_number_of_send
 
-        Bank.consts.dir_logs.mkdir() if not Bank.consts.dir_logs.is_dir() else None
+        if not Bank.consts.dir_logs.is_dir():
+            Bank.consts.dir_logs.mkdir()
         self.log_database = Bank.consts.dir_logs / f"branch_{self.id}.log"
 
         self._log(f"Branch {self.id} started working.", in_file=True, file_mode="w")
@@ -248,7 +252,6 @@ class Bank(BaseClass):
         receive = []
         send = []
         for branch in self.branches:
-
             send.append(
                 Thread(
                     target=self._do_common_transfer,
@@ -639,7 +642,7 @@ class Bank(BaseClass):
                 self.branches[bid]["address"],
             ) = self.branches[bid]["in_sock"].accept()
 
-        elif mode == "client":
+        else:  # client
             while True:
                 address, port = (
                     self.branches[bid]["address"],

--- a/commons.py
+++ b/commons.py
@@ -1,25 +1,25 @@
 import os
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 
 import yaml
 
 # Windows
-if os.name == 'nt':
+if os.name == "nt":
     import msvcrt
 # Posix (Linux, OS X)
 else:
+    import atexit
     import sys
     import termios
-    import atexit
     from select import select
-
 
 
 class Constants:
     dir_logs = Path("logs/")
     dir_bank = Path("bank/")
-    config_file = Path('config.yml')
+    config_file = Path("config.yml")
+
 
 class KBHit:
 
@@ -37,7 +37,7 @@ class KBHit:
         """
         Creates a KBHit object that you can call to do various keyboard things.
         """
-        if os.name == 'nt':
+        if os.name == "nt":
             pass
         else:
             # Save the terminal settings
@@ -46,7 +46,7 @@ class KBHit:
             self.old_term = termios.tcgetattr(self.fd)
 
             # New terminal setting unbuffered
-            self.new_term[3] = (self.new_term[3] & ~termios.ICANON & ~termios.ECHO)
+            self.new_term[3] = self.new_term[3] & ~termios.ICANON & ~termios.ECHO
             termios.tcsetattr(self.fd, termios.TCSAFLUSH, self.new_term)
 
             # Support normal-terminal reset at exit
@@ -54,10 +54,10 @@ class KBHit:
 
     def set_normal_term(self):
         """
-         Resets to normal terminal.  On Windows this is a no-op.
+        Resets to normal terminal.  On Windows this is a no-op.
         """
 
-        if os.name == 'nt':
+        if os.name == "nt":
             pass
         else:
             termios.tcsetattr(self.fd, termios.TCSAFLUSH, self.old_term)
@@ -68,12 +68,7 @@ class KBHit:
             Should not be called in the same program as getarrow().
         """
 
-        s = ''
-
-        if os.name == 'nt':
-            return msvcrt.getch().decode('utf-8')
-        else:
-            return sys.stdin.read(1)
+        return msvcrt.getch().decode("utf-8") if os.name == "nt" else sys.stdin.read(1)
 
     def getarrow(self):
         """Returns an arrow-key code after kbhit() has been called. Codes are
@@ -84,25 +79,24 @@ class KBHit:
         Should not be called in the same program as getch().
         """
 
-        if os.name == 'nt':
-            msvcrt.getch() # skip 0xE0
+        if os.name == "nt":
+            msvcrt.getch()  # skip 0xE0
             c = msvcrt.getch()
             vals = [72, 77, 80, 75]
-
         else:
             c = sys.stdin.read(3)[2]
             vals = [65, 67, 66, 68]
 
-        return vals.index(ord(c.decode('utf-8')))
+        return vals.index(ord(c.decode("utf-8")))
 
     def kbhit(self):
         """
         Returns True if keyboard character was hit, False otherwise.
         """
-        if os.name == 'nt':
+        if os.name == "nt":
             return msvcrt.kbhit()
         else:
-            dr,dw,de = select([sys.stdin], [], [], 0)
+            dr = select([sys.stdin], [], [], 0)[0]
             return dr != []
 
 
@@ -111,7 +105,9 @@ class BaseClass:
     Base class for both bank and inspector
     """
 
-    def _log(self, message, stdio: bool = True, in_file: bool = False, file_mode: str = "a"):
+    def _log(
+        self, message, stdio: bool = True, in_file: bool = False, file_mode: str = "a"
+    ):
 
         prefix = datetime.now().strftime("%Y-%m-%d:%H:%M:%S ")
 
@@ -129,7 +125,6 @@ class BaseClass:
             if branch["id"] == bid:
                 return i
 
-
     def get_config(self, path=None):
         """
         Gets and prepares configurations from yaml config file
@@ -138,9 +133,9 @@ class BaseClass:
         if path is None:
             path = Constants.config_file
 
-        with open(path, 'r') as yaml_file:
+        with open(path, "r") as yaml_file:
             self.config = yaml.load(yaml_file, Loader=yaml.FullLoader)
 
-        self.brnch_confs = self.config['branches']
-        self.bank_confs = self.config['bank']
-        self.inspctr_confs = self.config['inspector']
+        self.brnch_confs = self.config["branches"]
+        self.bank_confs = self.config["bank"]
+        self.inspctr_confs = self.config["inspector"]

--- a/inspector.py
+++ b/inspector.py
@@ -1,6 +1,8 @@
+from concurrent.futures import ThreadPoolExecutor
+
 import pickle
 import socket
-from threading import Lock, Thread
+from threading import Lock
 
 from bank import Bank
 from commons import BaseClass, Constants
@@ -186,9 +188,7 @@ class Inspector(BaseClass):
 
     def run(self):
 
-        threads = []
-        for i in range(self.n_branches):
-            threads.append(Thread(target=self.get_messages, args=(i,)))
-            threads[-1].start()
-        for i in range(self.n_branches):
-            threads[i].join()
+        with ThreadPoolExecutor(
+            max_workers=self.n_branches, thread_name_prefix="inspector_run"
+        ) as executor:
+            executor.map(self.get_messages, range(self.n_branches))

--- a/inspector.py
+++ b/inspector.py
@@ -1,20 +1,18 @@
 import pickle
-import threading
 import socket
-import random
+import threading
 from threading import Thread
 
-from commons import Constants, BaseClass
 from bank import Bank
+from commons import BaseClass, Constants
 
 
 class Inspector(BaseClass):
-
-    def __init__(self, address='localhost'):
+    def __init__(self, address="localhost"):
 
         self.get_config()
 
-        self.address = self.inspctr_confs['address']
+        self.address = self.inspctr_confs["address"]
         if self.address is None:
             self.address = address
 
@@ -26,7 +24,7 @@ class Inspector(BaseClass):
         self.lock = threading.Lock()
         self.n_global_snapshots = 0
 
-        self.log_database = Constants.dir_logs / self.inspctr_confs['log_file']
+        self.log_database = Constants.dir_logs / self.inspctr_confs["log_file"]
 
         self.connect_to_branches()
 
@@ -39,18 +37,22 @@ class Inspector(BaseClass):
         while True:
             Bank.load_class_vars()
             if len(Bank.branches_public_details) == self.n_branches:
-                self._log(f"All {self.n_branches} branches are open now. Resuming the process.")
+                self._log(
+                    f"All {self.n_branches} branches are open now. Resuming the process."
+                )
                 break
 
         for i in range(self.n_branches):
-            self.branches.append({
-                "id": Bank.branches_public_details[i]["id"],
-                "address": Bank.branches_public_details[i]["address"],
-                "in_sock": socket.socket(socket.AF_INET, socket.SOCK_STREAM),
-                "in_conn": None
-            })
+            self.branches.append(
+                {
+                    "id": Bank.branches_public_details[i]["id"],
+                    "address": Bank.branches_public_details[i]["address"],
+                    "in_sock": socket.socket(socket.AF_INET, socket.SOCK_STREAM),
+                    "in_conn": None,
+                }
+            )
 
-            port_in = self.inspctr_confs['port_base_in'] + self.branches[-1]["id"]
+            port_in = self.inspctr_confs["port_base_in"] + self.branches[-1]["id"]
             self.branches[-1]["in_sock"].bind((self.address, port_in))
             self.branches[-1]["in_sock"].listen(1)
 
@@ -58,16 +60,17 @@ class Inspector(BaseClass):
 
         bid = self._id_to_index(bid)
 
-        self.branches[bid]["in_conn"], self.branches[bid]["address"] \
-            = self.branches[bid]["in_sock"].accept()
+        self.branches[bid]["in_conn"], self.branches[bid]["address"] = self.branches[
+            bid
+        ]["in_sock"].accept()
 
         time_format = "%Y-%m-%d:%H:%M:%S"
-        c_sign = self.bank_confs['currency']['symbol']
-        c_unit = self.bank_confs['currency']['unit']
-        s_place = self.bank_confs['currency']['placement']
+        c_sign = self.bank_confs["currency"]["symbol"]
+        c_unit = self.bank_confs["currency"]["unit"]
+        s_place = self.bank_confs["currency"]["placement"]
         sign_before = f'{c_sign if s_place == "before" else ""}'
         sign_after = f'{c_sign if s_place == "after" else ""}'
-        merged_unit_sign_after = c_unit + ' ' + sign_after
+        merged_unit_sign_after = c_unit + " " + sign_after
 
         while True:
             pickled_data = self.branches[bid]["in_conn"].recv(4096)
@@ -79,9 +82,8 @@ class Inspector(BaseClass):
                 self.received_messages.append(message)
 
                 crspnd_msg = self.find_transfer_message(
-                    message,
-                    send_msg=True,
-                    remove=True)
+                    message, send_msg=True, remove=True
+                )
 
                 if crspnd_msg:
                     crspnd_msg["send_time"] = message["send_time"]
@@ -90,9 +92,8 @@ class Inspector(BaseClass):
                 self.sent_messages.append(message)
 
                 crspnd_msg = self.find_transfer_message(
-                    message,
-                    send_msg=False,
-                    remove=True)
+                    message, send_msg=False, remove=True
+                )
 
                 if crspnd_msg:
                     crspnd_msg["receive_time"] = message["receive_time"]
@@ -102,41 +103,46 @@ class Inspector(BaseClass):
                 self.n_global_snapshots += 1
                 total_balance = 0
                 log_message = (
-                    '\n=============================================='
-                    '=============================\n'
-                    f'Global Snapshot #{self.n_global_snapshots}'
-                    f'\tRequest Time:'
+                    "\n=============================================="
+                    "=============================\n"
+                    f"Global Snapshot #{self.n_global_snapshots}"
+                    f"\tRequest Time:"
                     f'{message["request_time"].strftime(time_format)}'
-                    f'\tPreparation Time:'
-                    f'{message["preparation_time"].strftime(time_format)}')
+                    f"\tPreparation Time:"
+                    f'{message["preparation_time"].strftime(time_format)}'
+                )
 
                 for snapshot in message["local_snapshots"]:
                     log_message += (
                         f'\nBranch {snapshot["id"]:>2}: Balance:'
-                        f'{sign_before}'
+                        f"{sign_before}"
                         f'{snapshot["balance"]}'
                         # f'{c_unit:<9} '
                         # f'{sign_after} '
-                        f'{merged_unit_sign_after:<8}'
-                        f'- In Channels: '
-                        f'{sign_before}'
+                        f"{merged_unit_sign_after:<8}"
+                        f"- In Channels: "
+                        f"{sign_before}"
                         f'{snapshot["in_channels"]}'
                         # f'{c_unit:<9} '
                         # f'{sign_after}')
-                        f'{merged_unit_sign_after:<6}')
+                        f"{merged_unit_sign_after:<6}"
+                    )
 
                     total_balance += snapshot["balance"] + snapshot["in_channels"]
 
                 log_message += (
-                    f'\nTotal Balance: '
-                    f'{sign_before}'
-                    f'{total_balance}'
+                    f"\nTotal Balance: "
+                    f"{sign_before}"
+                    f"{total_balance}"
                     # f'{c_unit:<9} '
                     # f'{sign_after}')
-                    f'{merged_unit_sign_after:<9}')
+                    f"{merged_unit_sign_after:<9}"
+                )
 
-                log_message += ('\n============================================='
-                    '==============================\n')
+                log_message += (
+                    "\n============================================="
+                    "==============================\n"
+                )
 
                 self._log(log_message, in_file=True)
 
@@ -144,22 +150,23 @@ class Inspector(BaseClass):
                 time_format = "%H:%M:%S"
                 log_message = (
                     f'sender: {crspnd_msg["sender_id"]:>2} - '
-                    f'send_time: '
+                    f"send_time: "
                     f'{crspnd_msg["send_time"].strftime(time_format)}'
-                    f' - amount:'
-                    f'{sign_before}'
+                    f" - amount:"
+                    f"{sign_before}"
                     f'{crspnd_msg["amount"]}'
                     # f'{c_unit:<9} '
                     # f'{sign_after}'
-                    f'{merged_unit_sign_after:<4}'
+                    f"{merged_unit_sign_after:<4}"
                     f' - receiver:{crspnd_msg["receiver_id"]:>2}'
-                    f' - receive_time: '
-                    f'{crspnd_msg["receive_time"].strftime(time_format)}')
+                    f" - receive_time: "
+                    f'{crspnd_msg["receive_time"].strftime(time_format)}'
+                )
 
                 self._log(log_message, in_file=True)
                 crspnd_msg = None
 
-    def find_transfer_message(self, message, send_msg: bool=False,remove=True):
+    def find_transfer_message(self, message, send_msg: bool = False, remove=True):
 
         self.lock.acquire()
 
@@ -168,9 +175,11 @@ class Inspector(BaseClass):
 
         for i, prev_message in enumerate(query_list):
 
-            if prev_message["amount"] == message["amount"] and \
-                prev_message["sender_id"] == message["sender_id"] and \
-                prev_message["receiver_id"] == message["receiver_id"]:
+            if (
+                prev_message["amount"] == message["amount"]
+                and prev_message["sender_id"] == message["sender_id"]
+                and prev_message["receiver_id"] == message["receiver_id"]
+            ):
 
                 if remove:
                     corresponding_message = query_list.pop(i)
@@ -187,7 +196,7 @@ class Inspector(BaseClass):
 
         threads = []
         for i in range(self.n_branches):
-            threads.append(Thread(target=self.get_messages, args=(i, )))
+            threads.append(Thread(target=self.get_messages, args=(i,)))
             threads[-1].start()
         for i in range(self.n_branches):
             threads[i].join()

--- a/inspector.py
+++ b/inspector.py
@@ -181,13 +181,8 @@ class Inspector(BaseClass):
                 and prev_message["receiver_id"] == message["receiver_id"]
             ):
 
-                if remove:
-                    corresponding_message = query_list.pop(i)
-                else:
-                    corresponding_message = query_list[i]
-
-                self.lock.release()
-                return corresponding_message
+                corresponding_message = query_list.pop(i) if remove else query_list[i]
+                break
 
         self.lock.release()
         return corresponding_message

--- a/main.py
+++ b/main.py
@@ -2,20 +2,35 @@ import argparse
 import shutil
 
 from bank import Bank
-from inspector import Inspector
 from commons import Constants
+from inspector import Inspector
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     # create and parse arguments
     ap = argparse.ArgumentParser()
 
-    ap.add_argument("-b", "--bank", required=False, action='store_true',
-                    help="Use this option to run an instance of Bank (a branch).")
-    ap.add_argument("-i", "--inspector", required=False, action='store_true',
-                    help="Use this option to run the inspector")
-    ap.add_argument("-c", "--clear", required=False, action='store_true',
-                    help="Clear the branches information file.")
+    ap.add_argument(
+        "-b",
+        "--bank",
+        required=False,
+        action="store_true",
+        help="Use this option to run an instance of Bank (a branch).",
+    )
+    ap.add_argument(
+        "-i",
+        "--inspector",
+        required=False,
+        action="store_true",
+        help="Use this option to run the inspector",
+    )
+    ap.add_argument(
+        "-c",
+        "--clear",
+        required=False,
+        action="store_true",
+        help="Clear the branches information file.",
+    )
 
     args = ap.parse_args()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyyaml
+pyyaml==6.0


### PR DESCRIPTION
1. Use `ThreadPoolExecutor` to make threads automatically join the calling thread
2. Use it to join hanging threads
3. Use `staticmethod` instead of `classmethod` when the class variable is not used
4. Use thread lock as a context manager
5. Remove unused parameter `id`
3. Formatted the code using `black`
4. Sorted imports with `isort`
5. Resolved `flake8` errors
6. Write a definite version in `requirements.txt`